### PR TITLE
Giving systemd-journald Reasonable Limit

### DIFF
--- a/configs/journald/journald.conf
+++ b/configs/journald/journald.conf
@@ -1,0 +1,10 @@
+[Journal]
+Storage=persistent
+RateLimitInterval=30s
+RateLimitBurst=1000
+SystemMaxUse=300M
+RuntimeMaxUse=300M
+ForwardToSyslog=no
+ForwardToKMsg=no
+ForwardToConsole=no
+ForwardToWall=no

--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -23,6 +23,11 @@ echo "Setting permissions."
 chmod -R 1710 /var/cache/apt
 chmod 1710 /etc/apt/sources.list
 
+# Deploy journald config and restart
+cp /vagrant/configs/journald/journald.conf /etc/systemd
+systemctl restart systemd-journald
+journalctl --verify
+
 # Configure and launch monit
 cp /vagrant/configs/monit/public-secrets.conf /etc/monit/conf.d
 


### PR DESCRIPTION
With this configuration file we can enforce that journald uses a reasonable amount of disk space as opposed to a seemingly unbounded amount of RAM.

If the issue persists (I haven't been able to recreate it) we can always `systemctl mask` it to /dev/null and forgo any use of journald.