### PR TITLE
No apport

### DIFF
--- a/configs/isolate.cron
+++ b/configs/isolate.cron
@@ -1,3 +1,4 @@
 @reboot mount -o remount,hidepid=2 /proc
 @reboot chmod 1733 /tmp /var/tmp /dev/shm
+@reboot chmod -R o-r /var/log /var/crash
 @reboot chmod o-rw /proc

--- a/configs/limits.conf
+++ b/configs/limits.conf
@@ -47,4 +47,5 @@
 @competitors        hard    cpu           3
 @competitors        hard    fsize         10000
 @competitors        hard    cputime       120
+@competitors        hard    core          unlimited
 # End of file

--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -36,7 +36,7 @@ if [ -f /tmp/hacksports/config.py ]; then
     cp /tmp/hacksports/config.py /opt/hacksports/config.py
 fi
 
-# disable apache if it's running 
+# disable apache if it's running
 systemctl disable apache2
 
 # remove default config and restart nginx
@@ -60,15 +60,15 @@ pip2 install requests
 groupadd competitors
 
 # disable ASLR
-if [ $(grep "kernel.randomize_va_space=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+if [ $(grep "kernel.randomize_va_space=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then
   echo "kernel.randomize_va_space=0" >> /etc/sysctl.conf
 fi
 # enable relative core paths
-if [ $(grep "fs.suid_dumpable=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+if [ $(grep "fs.suid_dumpable=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then
   echo "fs.suid_dumpable=0" >> /etc/sysctl.conf
 fi
 # disable apport
-if [ $(grep "kernel.core_pattern=./%e.core.%t" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+if [ $(grep "kernel.core_pattern=./%e.core.%t" /etc/sysctl.conf | wc -l) -eq "0" ]; then
   echo "kernel.core_pattern=./%e.core.%t" >> /etc/sysctl.conf
 fi
 sysctl -p
@@ -94,7 +94,7 @@ sudo systemctl add-wants default.target shell_manager.target
 
 # END of what was previously in picoCTF-shell-manager-install.sh
 
-# modify config.py 
+# modify config.py
 DEPLOY_SECRET="@@@ChAnGeMe!@@@"
 echo -e "\nHOSTNAME = '192.168.2.3'\n" >> /opt/hacksports/config.py
 echo -e "\nWEB_SERVER = 'http://192.168.2.2'\n" >> /opt/hacksports/config.py

--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -60,7 +60,17 @@ pip2 install requests
 groupadd competitors
 
 # disable ASLR
-echo "kernel.randomize_va_space=0" >> /etc/sysctl.conf
+if [ $(grep "kernel.randomize_va_space=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+  echo "kernel.randomize_va_space=0" >> /etc/sysctl.conf
+fi
+# enable relative core paths
+if [ $(grep "fs.suid_dumpable=0" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+  echo "fs.suid_dumpable=0" >> /etc/sysctl.conf
+fi
+# disable apport
+if [ $(grep "kernel.core_pattern=./%e.core.%t" /etc/sysctl.conf | wc -l) -eq "0" ]; then 
+  echo "kernel.core_pattern=./%e.core.%t" >> /etc/sysctl.conf
+fi
 sysctl -p
 
 # Securing the shell server
@@ -71,7 +81,7 @@ bash /vagrant/scripts/socket-limits.sh
 mount -o remount,hidepid=2 /proc
 chmod 1733 /tmp /var/tmp /dev/shm
 chmod 1111 /home/
-chmod -R o-r /var/log
+chmod -R o-r /var/log /var/crash
 chmod o-rw /proc
 
 # set hostname


### PR DESCRIPTION
disables apport, makes config changes so that competitors can generate core files in reasonable places when they crash non-SUID bins