### PR TITLE
Revert "Update shell_setup.sh to install extra packages"

### DIFF
--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -148,6 +148,3 @@ done
 
 # Fix dependencies
 shell_manager deploy -b challenge-sampler
-
-# Install software for users
-apt-get install gdb foremost vim-nox expect tmux screen tshark unzip bvi hexedit curl wget scalpel ipython -y


### PR DESCRIPTION
Reverts picoCTF/picoCTF-platform#18 Unable to setup shell server with these packages.